### PR TITLE
Fix duplicate listener registration

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix useToast effect dependencies to avoid duplicate listeners

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6841daf039308320988d1401ea226645